### PR TITLE
Enable usage of multiple databases

### DIFF
--- a/fastapi_async_sqlalchemy/middleware.py
+++ b/fastapi_async_sqlalchemy/middleware.py
@@ -8,10 +8,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.types import ASGIApp
 
-from fastapi_async_sqlalchemy.exceptions import (
-    MissingSessionError,
-    SessionNotInitialisedError,
-)
+from fastapi_async_sqlalchemy.exceptions import MissingSessionError, SessionNotInitialisedError
 
 try:
     from sqlalchemy.ext.asyncio import async_sessionmaker

--- a/fastapi_async_sqlalchemy/middleware.py
+++ b/fastapi_async_sqlalchemy/middleware.py
@@ -8,7 +8,10 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.types import ASGIApp
 
-from fastapi_async_sqlalchemy.exceptions import MissingSessionError, SessionNotInitialisedError
+from fastapi_async_sqlalchemy.exceptions import (
+    MissingSessionError,
+    SessionNotInitialisedError,
+)
 
 try:
     from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -16,80 +19,87 @@ except ImportError:
     from sqlalchemy.orm import sessionmaker as async_sessionmaker
 
 
-_Session: Optional[async_sessionmaker] = None
-_session: ContextVar[Optional[AsyncSession]] = ContextVar("_session", default=None)
+def create_middleware_and_session_proxy():
+    _Session: Optional[async_sessionmaker] = None
+    # Usage of context vars inside closures is not recommended, since they are not properly
+    # garbage collected, but in our use case context var is created on program startup and
+    # is used throughout the whole its lifecycle.
+    _session: ContextVar[Optional[AsyncSession]] = ContextVar("_session", default=None)
+
+    class SQLAlchemyMiddleware(BaseHTTPMiddleware):
+        def __init__(
+            self,
+            app: ASGIApp,
+            db_url: Optional[Union[str, URL]] = None,
+            custom_engine: Optional[Engine] = None,
+            engine_args: Dict = None,
+            session_args: Dict = None,
+            commit_on_exit: bool = False,
+        ):
+            super().__init__(app)
+            self.commit_on_exit = commit_on_exit
+            engine_args = engine_args or {}
+            session_args = session_args or {}
+
+            if not custom_engine and not db_url:
+                raise ValueError(
+                    "You need to pass a db_url or a custom_engine parameter."
+                )
+            if not custom_engine:
+                engine = create_async_engine(db_url, **engine_args)
+            else:
+                engine = custom_engine
+
+            nonlocal _Session
+            _Session = async_sessionmaker(
+                engine, class_=AsyncSession, expire_on_commit=False, **session_args
+            )
+
+        async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
+            async with db(commit_on_exit=self.commit_on_exit):
+                return await call_next(request)
+
+    class DBSessionMeta(type):
+        @property
+        def session(self) -> AsyncSession:
+            """Return an instance of Session local to the current async context."""
+            if _Session is None:
+                raise SessionNotInitialisedError
+
+            session = _session.get()
+            if session is None:
+                raise MissingSessionError
+
+            return session
+
+    class DBSession(metaclass=DBSessionMeta):
+        def __init__(self, session_args: Dict = None, commit_on_exit: bool = False):
+            self.token = None
+            self.session_args = session_args or {}
+            self.commit_on_exit = commit_on_exit
+
+        async def __aenter__(self):
+            if not isinstance(_Session, async_sessionmaker):
+                raise SessionNotInitialisedError
+
+            self.token = _session.set(_Session(**self.session_args))  # type: ignore
+            return type(self)
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            session = _session.get()
+
+            try:
+                if exc_type is not None:
+                    await session.rollback()
+                elif (
+                    self.commit_on_exit
+                ):  # Note: Changed this to elif to avoid commit after rollback
+                    await session.commit()
+            finally:
+                await session.close()
+                _session.reset(self.token)
+
+    return SQLAlchemyMiddleware, DBSession
 
 
-class SQLAlchemyMiddleware(BaseHTTPMiddleware):
-    def __init__(
-        self,
-        app: ASGIApp,
-        db_url: Optional[Union[str, URL]] = None,
-        custom_engine: Optional[Engine] = None,
-        engine_args: Dict = None,
-        session_args: Dict = None,
-        commit_on_exit: bool = False,
-    ):
-        super().__init__(app)
-        self.commit_on_exit = commit_on_exit
-        engine_args = engine_args or {}
-        session_args = session_args or {}
-
-        if not custom_engine and not db_url:
-            raise ValueError("You need to pass a db_url or a custom_engine parameter.")
-        if not custom_engine:
-            engine = create_async_engine(db_url, **engine_args)
-        else:
-            engine = custom_engine
-
-        global _Session
-        _Session = async_sessionmaker(
-            engine, class_=AsyncSession, expire_on_commit=False, **session_args
-        )
-
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
-        async with db(commit_on_exit=self.commit_on_exit):
-            return await call_next(request)
-
-
-class DBSessionMeta(type):
-    @property
-    def session(self) -> AsyncSession:
-        """Return an instance of Session local to the current async context."""
-        if _Session is None:
-            raise SessionNotInitialisedError
-
-        session = _session.get()
-        if session is None:
-            raise MissingSessionError
-
-        return session
-
-
-class DBSession(metaclass=DBSessionMeta):
-    def __init__(self, session_args: Dict = None, commit_on_exit: bool = False):
-        self.token = None
-        self.session_args = session_args or {}
-        self.commit_on_exit = commit_on_exit
-
-    async def __aenter__(self):
-        if not isinstance(_Session, async_sessionmaker):
-            raise SessionNotInitialisedError
-
-        self.token = _session.set(_Session(**self.session_args))  # type: ignore
-        return type(self)
-
-    async def __aexit__(self, exc_type, exc_value, traceback):
-        session = _session.get()
-
-        try:
-            if exc_type is not None:
-                await session.rollback()
-            elif self.commit_on_exit:  # Note: Changed this to elif to avoid commit after rollback
-                await session.commit()
-        finally:
-            await session.close()
-            _session.reset(self.token)
-
-
-db: DBSessionMeta = DBSession
+SQLAlchemyMiddleware, db = create_middleware_and_session_proxy()

--- a/fastapi_async_sqlalchemy/middleware.py
+++ b/fastapi_async_sqlalchemy/middleware.py
@@ -39,9 +39,7 @@ def create_middleware_and_session_proxy():
             session_args = session_args or {}
 
             if not custom_engine and not db_url:
-                raise ValueError(
-                    "You need to pass a db_url or a custom_engine parameter."
-                )
+                raise ValueError("You need to pass a db_url or a custom_engine parameter.")
             if not custom_engine:
                 engine = create_async_engine(db_url, **engine_args)
             else:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,6 +1,3 @@
-# from unittest.mock import Mock, patch
-import sys
-
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -53,16 +50,10 @@ async def test_init_incorrect_optional_args(app, SQLAlchemyMiddleware):
     with pytest.raises(TypeError) as exc_info:
         SQLAlchemyMiddleware(app, db_url=db_url, invalid_args="test")
 
-    if sys.version_info >= (3, 10):
-        assert (
-            exc_info.value.args[0]
-            == "SQLAlchemyMiddleware.__init__() got an unexpected keyword argument "
-            "'invalid_args'"
-        )
-    else:
-        assert (
-            exc_info.value.args[0] == "__init__() got an unexpected keyword argument 'invalid_args'"
-        )
+    assert (
+        "__init__() got an unexpected keyword argument 'invalid_args'"
+        in exc_info.value.args[0]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -50,10 +50,7 @@ async def test_init_incorrect_optional_args(app, SQLAlchemyMiddleware):
     with pytest.raises(TypeError) as exc_info:
         SQLAlchemyMiddleware(app, db_url=db_url, invalid_args="test")
 
-    assert (
-        "__init__() got an unexpected keyword argument 'invalid_args'"
-        in exc_info.value.args[0]
-    )
+    assert "__init__() got an unexpected keyword argument 'invalid_args'" in exc_info.value.args[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Added middleware factory to enable creation of multiple middlewares and session proxies.

This way it will be possible to use multiple databases at the same time, which was not possible previously, since there was only one middleware class and global session proxy.

Default `SQLAlchemyMiddleware` and global `db` are preserved for convenience and backward compatibility.